### PR TITLE
WS2812 refactor to fix #5

### DIFF
--- a/rp2-pio/examples/ws2812/main.go
+++ b/rp2-pio/examples/ws2812/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	const ws2812Pin = machine.GP16
+	const ws2812Pin = machine.GP0
 	sm, _ := pio.PIO0.ClaimStateMachine()
 	ws, err := piolib.NewWS2812(sm, ws2812Pin)
 	if err != nil {

--- a/rp2-pio/examples/ws2812/main.go
+++ b/rp2-pio/examples/ws2812/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	const ws2812Pin = machine.GP16
 	sm, _ := pio.PIO0.ClaimStateMachine()
-	ws, err := piolib.NewWS2812(sm, ws2812Pin, 400_000)
+	ws, err := piolib.NewWS2812(sm, ws2812Pin)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/rp2-pio/piolib/ws2812.go
+++ b/rp2-pio/piolib/ws2812.go
@@ -18,9 +18,9 @@ type WS2812 struct {
 func NewWS2812(sm pio.StateMachine, pin machine.Pin) (*WS2812, error) {
 	const (
 		nanosecondsInSecond = 1_000_000_000 // 1e9
-		t0h                 = 400           // 400ns
-		t0hcycles           = 3             // 3 cycles per t0h, from pio file.
-		f0h                 = nanosecondsInSecond / (t0h / t0hcycles)
+		t1l                 = 600           // 400ns
+		t1lcycles           = 6             // 3 cycles per t0h, from pio file.
+		f1l                 = nanosecondsInSecond / (t1l / t1lcycles)
 	)
 	sm.TryClaim() // SM should be claimed beforehand, we just guarantee it's claimed.
 	// We add the program to PIO memory and store it's offset.
@@ -38,14 +38,15 @@ func NewWS2812(sm pio.StateMachine, pin machine.Pin) (*WS2812, error) {
 	sm.Init(offset, cfg)
 	sm.SetEnabled(true)
 	dev := &WS2812{sm: sm, offset: offset}
-	dev.SetT0H(t0h)
+	dev.SetT1L(t1l)
 	return dev, nil
 }
 
-// SetT0H sets the period of the T0H pulse.
-func (ws *WS2812) SetT0H(d time.Duration) error {
-	f0h := uint32(1_000_000_000 / d)
-	whole, frac, err := pio.ClkDivFromFrequency(f0h, machine.CPUFrequency())
+// SetT1L sets the period of the T0H pulse.
+func (ws *WS2812) SetT1L(d time.Duration) error {
+	const t1lcycles = 6
+	d /= t1lcycles
+	whole, frac, err := pio.ClkDivFromPeriod(uint32(d), machine.CPUFrequency())
 	if err != nil {
 		return err
 	}

--- a/rp2-pio/piolib/ws2812.pio
+++ b/rp2-pio/piolib/ws2812.pio
@@ -26,7 +26,7 @@ t1h:
 	jmp entry_point
 
 t0l: ; T0H=3.5, done.
-	set pins, 0 [4] ; T0L=8 Accumulate 7 so that with this and next jmp reach 8 on low.
+	set pins, 0 [6] ; T0L=8 Accumulate 7 so that with this and next jmp reach 8 on low.
 	jmp x-- bitloop
 	jmp entry_point
 

--- a/rp2-pio/piolib/ws2812.pio
+++ b/rp2-pio/piolib/ws2812.pio
@@ -4,15 +4,30 @@ public entry_point:
 	pull
 	set x, 23 ; Loop over 24 bits
 
-bitloop:
-	set pins, 1 ; Drive pin high
-	out y, 1 [5] ; Shift 1 bit out, and write it to y
-	jmp !y skip ; Skip the extra delay if the bit was 0
-	nop [5]
 
-skip:
-	set pins, 0 [5]
-	jmp x-- bitloop ; Jump if x nonzero, and decrement x
+; The way this WS2812 program works is by delaying+nops 
+; to reach the High/Low level times for a 1 and a zero.
+; Here are the values taken from the datasheet. We take 1 cycles approximately equal to 100ns
+;
+; T0H | 0 code  | high voltage time 0.35us | ±150ns
+; T0L | 0 code  | low voltage time  0.8us  | ±150ns
+; T1H | 1 code  | high voltage time 0.7us  | ±150ns
+; T1L | 1 code  | low voltage time  0.6us  | ±150ns
+
+bitloop:
+	set pins, 1
+	out y, 1
+	jmp !y t0l ; Gotten to this point we've accumulated 3 cycles on High
+
+t1h:
+	nop [3]        ; T1H=7: Missing 4 cycles to reach 7 high.
+	set pins 0 [4] ; T1L=6: Set+5delay+jmp
+	jmp x-- bitloop
+	jmp entry_point
+
+t0l: ; T0H=3.5, done.
+	set pins, 0 [4] ; T0L=8 Accumulate 7 so that with this and next jmp reach 8 on low.
+	jmp x-- bitloop
 	jmp entry_point
 
 % go {

--- a/rp2-pio/piolib/ws2812_pio.go
+++ b/rp2-pio/piolib/ws2812_pio.go
@@ -23,7 +23,7 @@ var ws2812_ledInstructions = []uint16{
 		0xe400, //  6: set    pins, 0                [4] 
 		0x0042, //  7: jmp    x--, 2                     
 		0x0000, //  8: jmp    0                          
-		0xe400, //  9: set    pins, 0                [4] 
+		0xe600, //  9: set    pins, 0                [6] 
 		0x0042, // 10: jmp    x--, 2                     
 		0x0000, // 11: jmp    0                          
 		//     .wrap

--- a/rp2-pio/piolib/ws2812_pio.go
+++ b/rp2-pio/piolib/ws2812_pio.go
@@ -8,7 +8,7 @@ import (
 // ws2812_led
 
 const ws2812_ledWrapTarget = 0
-const ws2812_ledWrap = 8
+const ws2812_ledWrap = 11
 
 const ws2812_ledoffset_entry_point = 0
 
@@ -17,12 +17,15 @@ var ws2812_ledInstructions = []uint16{
 		0x80a0, //  0: pull   block                      
 		0xe037, //  1: set    x, 23                      
 		0xe001, //  2: set    pins, 1                    
-		0x6541, //  3: out    y, 1                   [5] 
-		0x0066, //  4: jmp    !y, 6                      
-		0xa542, //  5: nop                           [5] 
-		0xe500, //  6: set    pins, 0                [5] 
+		0x6041, //  3: out    y, 1                       
+		0x0069, //  4: jmp    !y, 9                      
+		0xa342, //  5: nop                           [3] 
+		0xe400, //  6: set    pins, 0                [4] 
 		0x0042, //  7: jmp    x--, 2                     
 		0x0000, //  8: jmp    0                          
+		0xe400, //  9: set    pins, 0                [4] 
+		0x0042, // 10: jmp    x--, 2                     
+		0x0000, // 11: jmp    0                          
 		//     .wrap
 }
 const ws2812_ledOrigin = -1


### PR DESCRIPTION
Hopefully Resolves #5, though I've observed my WS2812 is not lighting up with these changes.

@Gustavomurta could you please test this and see if it works on your WS2812?

Current implementation signal images:

<details>

![image](https://github.com/tinygo-org/pio/assets/26156425/ec62ad53-5068-45e9-8687-8a5d10ace362)
![image](https://github.com/tinygo-org/pio/assets/26156425/bbcad6d4-0c20-4f99-9c1c-63c0438d8045)

</details>