### PR TITLE
i2s: add example and simplify interface

### DIFF
--- a/rp2-pio/examples/i2s/main.go
+++ b/rp2-pio/examples/i2s/main.go
@@ -1,0 +1,61 @@
+// this example uses the rp2040 I2S peripheral to play a sine wave.
+// It uses a PCM5102A DAC to convert the digital signal to analog.
+// The sine wave is played at 44.1 kHz.
+// The sine wave is played in blocks of 32 samples.
+// The sine wave is played for 500 ms, then paused for 500 ms.
+// The sine wave is played indefinitely.
+// The sine wave is played on both the left and right channels.
+// connect PCM5102A DIN to GPIO2
+// connect PCM5102A BCK to GPIO3
+// connect PCM5102A LCK to GPIO4
+package main
+
+import (
+	"machine"
+	"time"
+
+	pio "github.com/tinygo-org/pio/rp2-pio"
+	"github.com/tinygo-org/pio/rp2-pio/piolib"
+)
+
+const (
+	i2sDataPin  = machine.GPIO2
+	i2sClockPin = machine.GPIO3
+
+	NUM_SAMPLES = 32
+	NUM_BLOCKS  = 5
+)
+
+// sine wave data
+var sine []int16 = []int16{
+	6392, 12539, 18204, 23169, 27244, 30272, 32137, 32767, 32137,
+	30272, 27244, 23169, 18204, 12539, 6392, 0, -6393, -12540,
+	-18205, -23170, -27245, -30273, -32138, -32767, -32138, -30273, -27245,
+	-23170, -18205, -12540, -6393, -1,
+}
+
+func main() {
+	time.Sleep(time.Millisecond * 500)
+
+	sm, _ := pio.PIO0.ClaimStateMachine()
+	i2s, err := piolib.NewI2S(sm, i2sDataPin, i2sClockPin)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	i2s.SetSampleFrequency(44100)
+
+	data := make([]uint32, NUM_SAMPLES*NUM_BLOCKS)
+	for i := 0; i < NUM_SAMPLES*NUM_BLOCKS; i++ {
+		data[i] = uint32(sine[i%NUM_SAMPLES]) | uint32(sine[i%NUM_SAMPLES])<<16
+	}
+
+	// Play the sine wave
+	for {
+		for i := 0; i < 50; i++ {
+			i2s.WriteStereo(data)
+		}
+
+		time.Sleep(time.Millisecond * 500)
+	}
+}

--- a/rp2-pio/piolib/i2s.go
+++ b/rp2-pio/piolib/i2s.go
@@ -1,19 +1,23 @@
-//go:build rp2040 && go1.18
+//go:build rp2040
 
 package piolib
 
 import (
+	"errors"
 	"machine"
 
 	pio "github.com/tinygo-org/pio/rp2-pio"
 )
 
+// I2S is a wrapper around a PIO state machine that implements I2S.
+// Currently only supports writing to the I2S peripheral.
 type I2S struct {
 	sm      pio.StateMachine
 	offset  uint8
 	writing bool
 }
 
+// NewI2S creates a new I2S peripheral using the given PIO state machine.
 func NewI2S(sm pio.StateMachine, data, clockAndNext machine.Pin) (*I2S, error) {
 	sm.TryClaim() // SM should be claimed beforehand, we just guarantee it's claimed.
 	Pio := sm.PIO()
@@ -49,10 +53,12 @@ func NewI2S(sm pio.StateMachine, data, clockAndNext machine.Pin) (*I2S, error) {
 	}
 	// This enables the state machine. Good practice to not require users to do this
 	// since they may be confused why nothing is happening.
-	i2s.Paused(false)
+	i2s.Enable(true)
+
 	return i2s, nil
 }
 
+// SetSampleFrequency sets the sample frequency of the I2S peripheral.
 func (i2s *I2S) SetSampleFrequency(freq uint32) error {
 	freq *= 32 // 32 bits per sample
 	whole, frac, err := pio.ClkDivFromFrequency(freq, machine.CPUFrequency())
@@ -63,12 +69,24 @@ func (i2s *I2S) SetSampleFrequency(freq uint32) error {
 	return nil
 }
 
+// WriteMono writes a mono audio buffer to the I2S peripheral.
 func (i2s *I2S) WriteMono(b []uint16) (int, error) {
 	return i2sWrite(i2s, b)
 }
 
+// WriteStereo writes a stereo audio buffer to the I2S peripheral.
 func (i2s *I2S) WriteStereo(b []uint32) (int, error) {
 	return i2sWrite(i2s, b)
+}
+
+// ReadMono reads a mono audio buffer from the I2S peripheral.
+func (i2s *I2S) ReadMono(p []uint16) (n int, err error) {
+	return 0, errors.ErrUnsupported
+}
+
+// ReadStereo reads a stereo audio buffer from the I2S peripheral.
+func (i2s *I2S) ReadStereo(p []uint32) (n int, err error) {
+	return 0, errors.ErrUnsupported
 }
 
 func i2sWrite[T uint16 | uint32](i2s *I2S, b []T) (int, error) {
@@ -94,10 +112,7 @@ func i2sWrite[T uint16 | uint32](i2s *I2S, b []T) (int, error) {
 	return len(b), nil
 }
 
-func (i2s *I2S) Paused(b bool) {
-	i2s.sm.SetEnabled(b)
-}
-
-func (i2s *I2S) Stop() {
-	i2s.writing = false
+// Enable enables or disables the I2S peripheral.
+func (i2s *I2S) Enable(enabled bool) {
+	i2s.sm.SetEnabled(enabled)
 }


### PR DESCRIPTION
This PR has 2 commits related to the `i2s` implementation. The first one makes a small fix to the i2s `Paused()` function. The other adds a very simple example that plays a stereo sine wave via a connected DAC such as the PCM5102A.