### PR TITLE
fix: correct errors in code generation

### DIFF
--- a/rp2-pio/examples/blinky/blink.pio
+++ b/rp2-pio/examples/blinky/blink.pio
@@ -33,7 +33,7 @@ import (
 // this is a raw helper function for use by the user which sets up the GPIO output, and configures the SM to output on a particular pin
 func blinkProgramInit(sm pio.StateMachine, offset uint8, pin machine.Pin) {
 	pin.Configure(machine.PinConfig{Mode: sm.PIO().PinMode()})
-	sm.SetConsecutivePinDirs(pin, 1, true)
+	sm.SetPindirsConsecutive(pin, 1, true)
 	cfg := blinkProgramDefaultConfig(offset)
 	cfg.SetSetPins(pin, 1)
 	sm.Init(offset, cfg)

--- a/rp2-pio/piolib/all_generate.go
+++ b/rp2-pio/piolib/all_generate.go
@@ -20,7 +20,6 @@ var (
 //go:generate pioasm -o go parallel8.pio  parallel8_pio.go
 //go:generate pioasm -o go pulsar.pio     pulsar_pio.go
 //go:generate pioasm -o go spi.pio        spi_pio.go
-//go:generate pioasm -o go ws2812.pio     ws2812_pio.go
 //go:generate pioasm -o go ws2812b.pio     ws2812b_pio.go
 //go:generate pioasm -o go i2s.pio        i2s_pio.go
 //go:generate pioasm -o go spi3w.pio       spi3w_pio.go


### PR DESCRIPTION
This PR corrects some errors in code generation probably been a while since the generation was executed. :smile_cat: 