### PR TITLE
Board specific frequencies and more accurate target blink rate

### DIFF
--- a/rp2-pio/examples/blinky/main.go
+++ b/rp2-pio/examples/blinky/main.go
@@ -25,10 +25,10 @@ func main() {
 	blinkPinForever(Pio.StateMachine(2), offset, machine.GPIO11, 1)
 }
 
-func blinkPinForever(sm pio.StateMachine, offset uint8, pin machine.Pin, freq uint) {
+func blinkPinForever(sm pio.StateMachine, offset uint8, pin machine.Pin, freq uint32) {
 	blinkProgramInit(sm, offset, pin)
-	const clockFreq = 125000000
+	clockFreq := machine.CPUFrequency()
 	sm.SetEnabled(true)
 	println("Blinking", int(pin), "at", freq, "Hz")
-	sm.TxPut(uint32(clockFreq / (2 * freq)))
+	sm.TxPut(uint32(clockFreq/(2*freq)) - 3)
 }


### PR DESCRIPTION
Use the machine.CPUFrequency() function to customize the frequency scaling to the working board. Also, in the form of "-3", account for the three clock cycles that the PIO takes to implement its fastest supported frequency blinking.

This addresses https://github.com/tinygo-org/pio/issues/25