### PR TITLE
i2s: Remove "writing" field and supporting code

### DIFF
--- a/rp2-pio/piolib/i2s.go
+++ b/rp2-pio/piolib/i2s.go
@@ -14,7 +14,6 @@ import (
 type I2S struct {
 	sm      pio.StateMachine
 	offset  uint8
-	writing bool
 }
 
 // NewI2S creates a new I2S peripheral using the given PIO state machine.
@@ -119,22 +118,15 @@ func i2sWrite[T uint16 | uint32](i2s *I2S, b []T) (int, error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
-	if i2s.writing {
-		return 0, errBusy
-	}
-	i2s.writing = true
 	i := 0
 	for i < len(b) {
 		if i2s.sm.IsTxFIFOFull() {
 			gosched()
 			continue
-		} else if !i2s.writing {
-			return i, nil
 		}
 		i2s.sm.TxPut(uint32(b[i]))
 		i++
 	}
-	i2s.writing = false
 	return len(b), nil
 }
 


### PR DESCRIPTION
The `writing` field of `type I2S` stopped being necessary when `I2S.Stop()` was removed in commit 7fa5907b1f09896c0153d630ced172deb47e4513.  This pull request removes it.