### PR TITLE
examples/parallel/tufty: fix ST7789 parallel display init

### DIFF
--- a/rp2-pio/examples/parallel/tufty/const.go
+++ b/rp2-pio/examples/parallel/tufty/const.go
@@ -1,39 +1,44 @@
 package main
 
 const (
-	SWRESET  byte = 0x01
-	TEOFF    byte = 0x34
-	TEON     byte = 0x35
-	MADCTL   byte = 0x36
-	COLMOD   byte = 0x3A
-	GCTRL    byte = 0xB7
-	VCOMS    byte = 0xBB
-	LCMCTRL  byte = 0xC0
-	VDVVRHEN byte = 0xC2
-	VRHS     byte = 0xC3
-	VDVS     byte = 0xC4
-	FRCTRL2  byte = 0xC6
-	PWCTRL1  byte = 0xD0
-	PORCTRL  byte = 0xB2
-	GMCTRP1  byte = 0xE0
-	GMCTRN1  byte = 0xE1
-	INVOFF   byte = 0x20
-	SLPOUT   byte = 0x11
-	DISPON   byte = 0x29
-	GAMSET   byte = 0x26
-	DISPOFF  byte = 0x28
-	RAMWR    byte = 0x2C
-	INVON    byte = 0x21
-	CASET    byte = 0x2A
-	RASET    byte = 0x2B
-	PWMFRSEL byte = 0xCC
+	SWRESET  = 0x01
+	TEOFF    = 0x34
+	TEON     = 0x35
+	STE      = 0x44
+	MADCTL   = 0x36
+	COLMOD   = 0x3A
+	RAMCTRL  = 0xB0
+	RGBCTRL  = 0xB1
+	GCTRL    = 0xB7
+	VCOMS    = 0xBB
+	LCMCTRL  = 0xC0
+	VDVVRHEN = 0xC2
+	VRHS     = 0xC3
+	VDVS     = 0xC4
+	FRCTRL2  = 0xC6
+	PWCTRL1  = 0xD0
+	GATESEL  = 0xD6
+	PORCTRL  = 0xB2
+	GMCTRP1  = 0xE0
+	GMCTRN1  = 0xE1
+	INVOFF   = 0x20
+	SLPIN    = 0x10
+	SLPOUT   = 0x11
+	DISPON   = 0x29
+	GAMSET   = 0x26
+	DISPOFF  = 0x28
+	RAMWR    = 0x2C
+	INVON    = 0x21
+	CASET    = 0x2A
+	RASET    = 0x2B
+	PWMFRSEL = 0xCC
 )
 
 const (
-	ROW_ORDER   uint8 = 0b10000000
-	COL_ORDER   uint8 = 0b01000000
-	SWAP_XY     uint8 = 0b00100000 // AKA "MV"
-	SCAN_ORDER  uint8 = 0b00010000
-	RGB_BGR     uint8 = 0b00001000
-	HORIZ_ORDER uint8 = 0b00000100
+	ROW_ORDER   = 0b10000000
+	COL_ORDER   = 0b01000000
+	SWAP_XY     = 0b00100000 // AKA "MV"
+	SCAN_ORDER  = 0b00010000
+	RGB_BGR     = 0b00001000
+	HORIZ_ORDER = 0b00000100
 )

--- a/rp2-pio/examples/parallel/tufty/st7789.go
+++ b/rp2-pio/examples/parallel/tufty/st7789.go
@@ -95,28 +95,35 @@ func (st *ST7789) CommonInit() {
 }
 
 func (st *ST7789) configureDisplayRotation(rotation Rotation) {
-	var madctl uint8
-	var rotate180 bool
-	caset := []uint16{0, 0}
-	raset := []uint16{0, 0}
+	st.rotation = rotation
+	portrait := rotation == Rotation90 || rotation == Rotation270
+	flipped := rotation == Rotation180 || rotation == Rotation270
 
-	if rotation == Rotation180 || rotation == Rotation90 {
-		rotate180 = true
-	}
-	if rotation == Rotation90 || rotation == Rotation270 {
-		st.width, st.height = st.height, st.width
-	}
-
-	caset[0] = 0
-	caset[1] = 319
-	raset[0] = 0
-	raset[1] = 239
-	if rotate180 {
-		madctl = COL_ORDER
+	if portrait {
+		st.width, st.height = 240, 320
 	} else {
-		madctl = ROW_ORDER
+		st.width, st.height = 320, 240
 	}
-	madctl |= SWAP_XY | SCAN_ORDER
+
+	var madctl uint8
+	if portrait {
+		// MV=0: DDRAM columns/rows map directly to physical X/Y.
+		if flipped {
+			madctl = ROW_ORDER | COL_ORDER
+		}
+	} else {
+		// MV=1: DDRAM columns/rows are transposed onto physical Y/X.
+		if flipped {
+			madctl = COL_ORDER
+		} else {
+			madctl = ROW_ORDER
+		}
+		madctl |= SWAP_XY
+	}
+	madctl |= SCAN_ORDER
+
+	caset := []uint16{0, st.width - 1}
+	raset := []uint16{0, st.height - 1}
 
 	// CASET/RASET take big-endian 16 bit values.
 	st.command(CASET, []byte{byte(caset[0] >> 8), byte(caset[0]), byte(caset[1] >> 8), byte(caset[1])})

--- a/rp2-pio/examples/parallel/tufty/st7789.go
+++ b/rp2-pio/examples/parallel/tufty/st7789.go
@@ -29,82 +29,62 @@ type ST7789 struct {
 }
 
 func (st *ST7789) SetBacklight(on bool) {
-	if st.bl != machine.NoPin {
-		pwm := machine.PWM1 // LCD LED on Tufty2040 corresponds to PWM1.
-		// Configure the PWM
-		pwm.Configure(machine.PWMConfig{})
-		ch, err := pwm.Channel(st.bl)
-		if err != nil {
-			println(err.Error())
-			return
-		}
-		if on {
-			pwm.Set(ch, pwm.Top())
-			return
-		}
-		pwm.Set(ch, 0)
+	if st.bl == machine.NoPin {
 		return
 	}
-	println("no backlight pin defined")
+	pwm := machine.PWM1 // LCD LED on Tufty2040 corresponds to PWM1.
+	pwm.Configure(machine.PWMConfig{})
+	ch, err := pwm.Channel(st.bl)
+	if err != nil {
+		return
+	}
+	if on {
+		pwm.Set(ch, pwm.Top()) // full brightness
+		return
+	}
+	pwm.Set(ch, 0) // off
 }
 
 func (st *ST7789) CommonInit() {
 	st.dc.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	st.cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	st.cs.High() // Deassert chip select until the first command.
 
-	// Configure Backlight Pin
+	// Keep the panel dark until the init sequence has finished.
 	st.SetBacklight(false)
 
-	println("SWRESET")
-	st.command(SWRESET, []byte{})
+	st.command(SWRESET, []byte{}) // software reset
 
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond) // reset needs 120ms before further commands
 
-	//Common Init
-	println("TEON")
-	st.command(TEON, []byte{})
-	println("COLMOD")
-	st.command(COLMOD, []byte{0x05}) // 16 bits per pixel
-	println("PORCTRL")
-	st.command(PORCTRL, []byte{0x0c, 0x0c, 0x00, 0x33, 0x33})
-	println("LCMCTRL")
-	st.command(LCMCTRL, []byte{0x2c})
-	println("VDVVHREN")
-	st.command(VDVVRHEN, []byte{0x01})
-	println("VRHS")
-	st.command(VRHS, []byte{0x12})
-	println("VDVS")
-	st.command(VDVS, []byte{0x20})
-	println("PWCTRL1")
-	st.command(PWCTRL1, []byte{0xa4, 0xa1})
-	println("FRCTRL2")
-	st.command(FRCTRL2, []byte{0x0f})
+	st.command(COLMOD, []byte{0x05})                          // 16 bits per pixel
+	st.command(PORCTRL, []byte{0x0c, 0x0c, 0x00, 0x33, 0x33}) // porch intervals
+	st.command(LCMCTRL, []byte{0x2c})                         // LCM control
+	st.command(VDVVRHEN, []byte{0x01})                        // take VDV and VRH from the command registers
+	st.command(VRHS, []byte{0x12})                            // VRH ~4.45V
+	st.command(VDVS, []byte{0x20})                            // VDV 0V
+	st.command(PWCTRL1, []byte{0xa4, 0xa1})                   // AVDD 6.8V, AVCL -4.8V, VDS 2.3V
+	st.command(FRCTRL2, []byte{0x0f})                         // 60Hz frame rate
+	st.command(RAMCTRL, []byte{0x00, 0xc0})                   // MCU interface, big endian pixel data
+	st.command(GCTRL, []byte{0x35})                           // gate voltages VGH 13.26V, VGL -10.43V
+	st.command(VCOMS, []byte{0x1b})                           // VCOM 0.875V
 
-	// Tufty is 320x240
-	println("GCTRL")
-	st.command(GCTRL, []byte{0x35})
-	println("VCOMS")
-	st.command(VCOMS, []byte{0x1f})
-	println("0xD6")
-	st.command(0xD6, []byte{0xa1}) // ???
-	println("GMCTRP1")
-	st.command(GMCTRP1, []byte{0xD0, 0x08, 0x11, 0x08, 0x0C, 0x15, 0x39, 0x33, 0x50, 0x36, 0x13, 0x14, 0x29, 0x2D})
-	println("GMCTRN1")
-	st.command(GMCTRN1, []byte{0xD0, 0x08, 0x10, 0x08, 0x06, 0x06, 0x39, 0x44, 0x51, 0x0B, 0x16, 0x14, 0x2F, 0x31})
+	// Gamma correction curves tuned for the Tufty panel.
+	st.command(GMCTRP1, []byte{0xf0, 0x00, 0x06, 0x04, 0x05, 0x05, 0x31, 0x44, 0x48, 0x36, 0x12, 0x12, 0x2b, 0x34}) // positive
+	st.command(GMCTRN1, []byte{0xf0, 0x0b, 0x0f, 0x0f, 0x0d, 0x26, 0x31, 0x43, 0x47, 0x38, 0x14, 0x14, 0x2c, 0x32}) // negative
 
-	println("INVON")
-	st.command(INVON, []byte{})
-	println("SLPOUT")
-	st.command(SLPOUT, []byte{})
-	println("DISPON")
-	st.command(DISPON, []byte{})
+	st.command(INVON, []byte{})  // set inversion mode
+	st.command(SLPOUT, []byte{}) // leave sleep mode
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) // sleep out needs 120ms before the display is driven
 
-	// Configure Display Rotation
-	st.configureDisplayRotation(st.rotation)
+	st.configureDisplayRotation(st.rotation) // set the addressing window and scan order
 
-	println("Turning on backlight")
+	st.command(TEON, []byte{0x00})      // enable frame sync signal
+	st.command(STE, []byte{0x00, 0x00}) // sync on scanline 0
+	st.command(DISPON, []byte{})        // turn display on
+
+	// Panel is now driven, so it is safe to light the backlight.
 	if st.bl != machine.NoPin {
 		time.Sleep(50 * time.Millisecond)
 		st.SetBacklight(true)
@@ -135,13 +115,9 @@ func (st *ST7789) configureDisplayRotation(rotation Rotation) {
 	}
 	madctl |= SWAP_XY | SCAN_ORDER
 
-	caset[0] = (caset[0] << 8) | ((caset[0] >> 8) & 0xFF)
-	caset[1] = (caset[1] << 8) | ((caset[1] >> 8) & 0xFF)
-	raset[0] = (raset[0] << 8) | ((raset[0] >> 8) & 0xFF)
-	raset[1] = (raset[1] << 8) | ((raset[1] >> 8) & 0xFF)
-
-	st.command(CASET, []byte{byte(caset[0] >> 8), byte(caset[0] & 0xff), byte(caset[1] >> 8), byte(caset[1] & 0xff)})
-	st.command(CASET, []byte{byte(raset[0] >> 8), byte(raset[0] & 0xff), byte(raset[1] >> 8), byte(raset[1] & 0xff)})
+	// CASET/RASET take big-endian 16 bit values.
+	st.command(CASET, []byte{byte(caset[0] >> 8), byte(caset[0]), byte(caset[1] >> 8), byte(caset[1])})
+	st.command(RASET, []byte{byte(raset[0] >> 8), byte(raset[0]), byte(raset[1] >> 8), byte(raset[1])})
 	st.command(MADCTL, []byte{madctl})
 }
 
@@ -149,13 +125,14 @@ func (st *ST7789) command(command byte, data []byte) {
 	st.dc.Low()
 	st.cs.Low()
 	st.pl.Tx8([]byte{command})
-	// st.writeBlockingParallel([]byte{command}, 1)
 
 	if len(data) > 0 {
 		st.dc.High()
 		st.pl.Tx8(data)
-		// st.writeBlockingParallel(data, len(data))
 	}
+	// Tx8 returns on TX-stall, which can be a couple of PIO cycles before the
+	// final WR rising edge. Let the bus settle before deasserting CS.
+	time.Sleep(10 * time.Microsecond)
 	st.cs.High()
 }
 
@@ -171,13 +148,10 @@ func (st *ST7789) Size() (w, h int16) {
 }
 
 func (st *ST7789) setWindow(x, y, w, h int16) {
-	x += 0
-	y += 0
 	copy(st.buf[:4], []uint8{uint8(x >> 8), uint8(x), uint8((x + w - 1) >> 8), uint8(x + w - 1)})
 	st.command(CASET, st.buf[:4])
 	copy(st.buf[:4], []uint8{uint8(y >> 8), uint8(y), uint8((y + h - 1) >> 8), uint8(y + h - 1)})
 	st.command(RASET, st.buf[:4])
-	st.command(RAMWR, []byte{})
 }
 
 func (st *ST7789) FillRectangle(x, y, width, height int16, c color.RGBA) error {
@@ -187,15 +161,33 @@ func (st *ST7789) FillRectangle(x, y, width, height int16, c color.RGBA) error {
 		return errors.New("rectangle coordinates outside display area")
 	}
 	st.setWindow(x, y, width, height)
-	c565 := RGBATo565(c)
-	c1 := uint8(c565 >> 8)
-	c2 := uint8(c565)
 
-	fb := make([]uint8, st.width*st.height*2)
-	for i := 0; i < len(fb)/2; i++ {
-		fb[i*2] = c1
-		fb[i*2+1] = c2
+	c565 := RGBATo565(c)
+	// Pre-fill a small chunk once and stream it repeatedly rather than
+	// allocating a whole framebuffer.
+	var chunk [512]byte
+	for j := 0; j < len(chunk); j += 2 {
+		chunk[j] = uint8(c565 >> 8)
+		chunk[j+1] = uint8(c565)
 	}
-	st.command(RAMWR, fb)
+
+	st.dc.Low()
+	st.cs.Low()
+	st.pl.Tx8([]byte{RAMWR})
+	st.dc.High()
+	remaining := int(width) * int(height) * 2
+	for remaining > 0 {
+		n := remaining
+		if n > len(chunk) {
+			n = len(chunk)
+		}
+		if err := st.pl.Tx8(chunk[:n]); err != nil {
+			st.cs.High()
+			return err
+		}
+		remaining -= n
+	}
+	time.Sleep(10 * time.Microsecond)
+	st.cs.High()
 	return nil
 }

--- a/rp2-pio/examples/parallel/tufty/st7789.go
+++ b/rp2-pio/examples/parallel/tufty/st7789.go
@@ -112,9 +112,9 @@ func (st *ST7789) configureDisplayRotation(rotation Rotation) {
 	raset[0] = 0
 	raset[1] = 239
 	if rotate180 {
-		madctl = ROW_ORDER
-	} else {
 		madctl = COL_ORDER
+	} else {
+		madctl = ROW_ORDER
 	}
 	madctl |= SWAP_XY | SCAN_ORDER
 
@@ -130,6 +130,10 @@ func (st *ST7789) command(command byte, data []byte) {
 	st.pl.Tx8([]byte{command})
 
 	if len(data) > 0 {
+		// Tx8 can return a couple of PIO cycles before the command byte's
+		// final WR edge actually lands. Settle before flipping DC, so the
+		// data phase doesn't start (and DC doesn't change) mid-command.
+		time.Sleep(10 * time.Microsecond)
 		st.dc.High()
 		st.pl.Tx8(data)
 	}
@@ -177,6 +181,9 @@ func (st *ST7789) FillRectangle(x, y, width, height int16, c color.RGBA) error {
 	st.dc.Low()
 	st.cs.Low()
 	st.pl.Tx8([]byte{RAMWR})
+	// Same settle as command(): let the RAMWR command byte's WR edge land
+	// before flipping DC into the data phase.
+	time.Sleep(10 * time.Microsecond)
 	st.dc.High()
 	remaining := int(width) * int(height) * 2
 	for remaining > 0 {

--- a/rp2-pio/examples/parallel/tufty/st7789.go
+++ b/rp2-pio/examples/parallel/tufty/st7789.go
@@ -46,9 +46,12 @@ func (st *ST7789) SetBacklight(on bool) {
 }
 
 func (st *ST7789) CommonInit() {
-	st.dc.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	st.cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	st.cs.High() // Deassert chip select until the first command.
+	// Assume the caller has configured cs/dc/rd as outputs at safe idle
+	// levels (CS high, DC high, RD high) BEFORE the PIO parallel bus was
+	// brought up, so no stray bytes from PIO startup were latched by the
+	// panel. Give the panel a brief moment for VDDI/VCI to settle after any
+	// warm reset before issuing the first command.
+	time.Sleep(10 * time.Millisecond)
 
 	// Keep the panel dark until the init sequence has finished.
 	st.SetBacklight(false)

--- a/rp2-pio/examples/parallel/tufty/tufty.go
+++ b/rp2-pio/examples/parallel/tufty/tufty.go
@@ -67,9 +67,88 @@ func main() {
 
 	display.CommonInit()
 
+	rotations := []Rotation{Rotation0, Rotation90, Rotation180, Rotation270}
+	palette := []color.RGBA{
+		{255, 255, 255, 255}, // white
+		{255, 0, 0, 255},     // red
+		{0, 255, 0, 255},     // green
+		{255, 255, 0, 255},   // yellow
+	}
+	black := color.RGBA{0, 0, 0, 255}
 	blue := color.RGBA{0, 0, 255, 255}
-	if err := display.FillRectangle(0, 0, 320, 240, blue); err != nil {
-		panic(err.Error())
+
+	pause := func() { time.Sleep(2 * time.Second) }
+
+	for {
+		for _, rotation := range rotations {
+			// Reposition the addressing window and MADCTL for the new
+			// orientation. This is much cheaper than a full CommonInit,
+			// which would re-run the panel's power-on sequence.
+			display.configureDisplayRotation(rotation)
+			w, h := display.Size()
+
+			// Stage 1: full screen blue fill.
+			if err := display.FillRectangle(0, 0, w, h, blue); err != nil {
+				panic(err.Error())
+			}
+			pause()
+
+			// Stage 2: quadrant fill, white/red/green/yellow, TL/TR/BL/BR.
+			hw, hh := w/2, h/2
+			if err := display.FillRectangle(0, 0, hw, hh, palette[0]); err != nil {
+				panic(err.Error())
+			}
+			if err := display.FillRectangle(hw, 0, w-hw, hh, palette[1]); err != nil {
+				panic(err.Error())
+			}
+			if err := display.FillRectangle(0, hh, hw, h-hh, palette[2]); err != nil {
+				panic(err.Error())
+			}
+			if err := display.FillRectangle(hw, hh, w-hw, h-hh, palette[3]); err != nil {
+				panic(err.Error())
+			}
+			pause()
+
+			// Stage 3: four colored boxes, one per corner, on a black background.
+			if err := display.FillRectangle(0, 0, w, h, black); err != nil {
+				panic(err.Error())
+			}
+			boxW, boxH := w/6, h/6
+			if err := display.FillRectangle(0, 0, boxW, boxH, palette[0]); err != nil {
+				panic(err.Error())
+			}
+			if err := display.FillRectangle(w-boxW, 0, boxW, boxH, palette[1]); err != nil {
+				panic(err.Error())
+			}
+			if err := display.FillRectangle(0, h-boxH, boxW, boxH, palette[2]); err != nil {
+				panic(err.Error())
+			}
+			if err := display.FillRectangle(w-boxW, h-boxH, boxW, boxH, palette[3]); err != nil {
+				panic(err.Error())
+			}
+			pause()
+
+			// Stage 4: fill stress test. Concentric 1px rings, alternating
+			// a palette color and black, shrinking the window by 2px (1px
+			// per edge) each fill.
+			x, y, rw, rh := int16(0), int16(0), w, h
+			ci := 0
+			for rw > 0 && rh > 0 {
+				if err := display.FillRectangle(x, y, rw, rh, palette[ci%len(palette)]); err != nil {
+					panic(err.Error())
+				}
+				ci++
+				x, y, rw, rh = x+1, y+1, rw-2, rh-2
+				if rw <= 0 || rh <= 0 {
+					break
+				}
+				if err := display.FillRectangle(x, y, rw, rh, black); err != nil {
+					panic(err.Error())
+				}
+				x, y, rw, rh = x+1, y+1, rw-2, rh-2
+			}
+			pause()
+		}
 	}
 }
 

--- a/rp2-pio/examples/parallel/tufty/tufty.go
+++ b/rp2-pio/examples/parallel/tufty/tufty.go
@@ -22,6 +22,19 @@ const (
 func main() {
 	time.Sleep(5 * time.Second) // wait for the USB CDC console to enumerate
 
+	// Configure control pins to safe idle levels BEFORE bringing up the PIO
+	// parallel bus. If CS or DC are floating while the PIO state machine
+	// starts and puts its initial (zeroed) OSR contents on the bus, the
+	// panel intermittently latches stray bytes as commands, leaving the
+	// display in an unknown state that manifests as "sometimes it doesn't
+	// come up after reset".
+	csPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	csPin.High() // CS idle high (panel deselected)
+	dcPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	dcPin.High() // DC idle in data mode
+	rdPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	rdPin.High() // RD held high so the panel accepts writes
+
 	const MHz = 1_000_000
 	sm, _ := pio.PIO0.ClaimStateMachine()
 
@@ -46,11 +59,6 @@ func main() {
 		height:   240,
 		rotation: Rotation0,
 	}
-
-	// RD must be configured as an output and held high (deasserted) for the
-	// ST7789 to accept writes on the parallel bus.
-	rdPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	rdPin.High()
 
 	// Feed the PIO TX FIFO by DMA so large pixel writes do not block on the CPU.
 	if err := display.pl.EnableDMA(true); err != nil {

--- a/rp2-pio/examples/parallel/tufty/tufty.go
+++ b/rp2-pio/examples/parallel/tufty/tufty.go
@@ -9,23 +9,23 @@ import (
 	"github.com/tinygo-org/pio/rp2-pio/piolib"
 )
 
-const clockHz = 133000000
-
 // Pimoroni Tufty definitions https://tinygo.org/docs/reference/microcontrollers/tufty2040/
 const (
-	csPin  = machine.GP10
-	dcPin  = machine.GP11
-	wrPin  = machine.GP12
-	db0Pin = machine.GP14
-	rdPin  = machine.GP13
-	blPin  = machine.GP2
+	csPin  = machine.GPIO10 // LCD_CS
+	dcPin  = machine.GPIO11 // LCD_DC
+	wrPin  = machine.GPIO12 // LCD_WR
+	db0Pin = machine.GPIO14 // LCD_DB0..DB7 = GPIO14..GPIO21
+	rdPin  = machine.GPIO13 // LCD_RD
+	blPin  = machine.GPIO2  // LCD_BACKLIGHT
 )
 
 func main() {
-	time.Sleep(5 * time.Second)
-	println("Initializing Display")
+	time.Sleep(5 * time.Second) // wait for the USB CDC console to enumerate
+
 	const MHz = 1_000_000
 	sm, _ := pio.PIO0.ClaimStateMachine()
+
+	// Drive the 8 bit parallel bus from PIO, clocking data out on WR.
 	p8tx, err := piolib.NewParallel(sm, piolib.ParallelConfig{
 		Baud:        1 * MHz,
 		Clock:       wrPin,
@@ -47,21 +47,22 @@ func main() {
 		rotation: Rotation0,
 	}
 
-	if err != nil {
-		panic(err.Error())
-	}
-	display.pl.Tx8([]byte("Hello World"))
-	// Setup DMA
-	println("Setting Up DMA")
-	// display.pl.EnableDMA(2)
+	// RD must be configured as an output and held high (deasserted) for the
+	// ST7789 to accept writes on the parallel bus.
+	rdPin.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	rdPin.High()
 
-	println("Display Common Init")
+	// Feed the PIO TX FIFO by DMA so large pixel writes do not block on the CPU.
+	if err := display.pl.EnableDMA(true); err != nil {
+		panic(err.Error())
+	}
+
 	display.CommonInit()
 
-	println("Making Screen Blue")
-	blue := color.RGBA{255, 255, 255, 255}
-	display.FillRectangle(0, 0, 320, 240, blue)
+	blue := color.RGBA{0, 0, 255, 255}
+	if err := display.FillRectangle(0, 0, 320, 240, blue); err != nil {
+		panic(err.Error())
+	}
 }
 
 type Displayer interface {


### PR DESCRIPTION
The Tufty parallel display example did not drive the panel. Several independent problems, any one of which was enough to leave the screen blank:

- `rdPin` was never configured as an output, so `rdPin.High()` was a no-op on a floating input. RD must be held high for the ST7789 to accept writes.
- `configureDisplayRotation` sent `CASET` twice, so the row address window was never set. It also byte swapped the `CASET`/`RASET` values and then emitted them big endian, swapping them twice.
- `machine.GP10` and friends do not exist, so the example did not compile. Use the `GPIOnn` constants for the same pins.

While here, correct some other problems:

- `FillRectangle` allocated a 150KB framebuffer regardless of the size of the rectangle requested, and issued `RAMWR` twice because `setWindow` had already sent it. It now streams a small pre-filled chunk with CS held low for the duration.
- Deassert CS before the first command, and let the bus settle before raising CS so the final WR edge lands while the panel is still selected.
- Drop a stray `Tx8("Hello World")` issued before CS and DC were configured.
- Fill with blue rather than white, as the surrounding code claims.

The init sequence values are updated to match Pimoroni's 320x240 Tufty profile, and each command is now commented with what it does in place of the `println` tracing used to debug this.

## Testing

Built with TinyGo 0.42.0 for `-target=tufty2040` and flashed to a Tufty 2040. The display shows a full screen blue fill.


<img width="552" height="310" alt="DAD30273-2B0F-4C16-A58D-39DA99A49F97_4_5005_c" src="https://github.com/user-attachments/assets/9c9f0c4f-a4e0-469f-a475-2bf183d5048e" />

