### PR TITLE
Support RP2350B parallel high GPIO pins

### DIFF
--- a/rp2-pio/piolib/parallel.go
+++ b/rp2-pio/piolib/parallel.go
@@ -32,6 +32,17 @@ type ParallelConfig struct {
 }
 
 func NewParallel(sm pio.StateMachine, cfg ParallelConfig) (*Parallel, error) {
+	if cfg.BusWidth == 0 {
+		return nil, errors.New("zero bus width")
+	}
+	if cfg.BusWidth > 32 {
+		return nil, errors.New("bus width exceeds 32 pins")
+	}
+	pins, err := parallelPinConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	const sideSetBitCount = 1
 	const programOrigin = -1
 	asm := pio.AssemblerV0{
@@ -49,8 +60,6 @@ func NewParallel(sm pio.StateMachine, cfg ParallelConfig) (*Parallel, error) {
 		return nil, errors.New("bits per pull must be multiple of bus width")
 	} else if cfg.BitsPerPull < cfg.BusWidth {
 		return nil, errors.New("bits per pull must be greater or equal to bus width")
-	} else if cfg.BusWidth == 0 {
-		return nil, errors.New("zero bus width")
 	}
 	piofreq := cfg.Baud * uint32(len(program))
 	whole, frac, err := pio.ClkDivFromFrequency(piofreq, machine.CPUFrequency())
@@ -64,28 +73,26 @@ func NewParallel(sm pio.StateMachine, cfg ParallelConfig) (*Parallel, error) {
 	if err != nil {
 		return nil, err
 	}
+	setParallelGPIOBase(Pio, pins.gpioBase)
 
-	clkMask := uint32(1) << cfg.Clock
-	pinMask := clkMask
 	pinCfg := machine.PinConfig{Mode: Pio.PinMode()}
 	for pinoff := 0; pinoff < int(cfg.BusWidth); pinoff++ {
 		pin := cfg.DataBase + machine.Pin(pinoff)
-		pinMask |= 1 << pin
 		pin.Configure(pinCfg)
 	}
 	cfg.Clock.Configure(pinCfg)
 
 	scfg := asm.DefaultStateMachineConfig(progOffset, program[:])
 
-	scfg.SetOutPins(cfg.DataBase, cfg.BusWidth)
+	scfg.SetOutPins(pins.dataBase, cfg.BusWidth)
 	scfg.SetOutShift(true, true, uint16(cfg.BitsPerPull))
-	scfg.SetSidesetPins(cfg.Clock)
+	scfg.SetSidesetPins(pins.clock)
 
 	scfg.SetClkDivIntFrac(whole, frac)
 	scfg.SetFIFOJoin(pio.FifoJoinTx)
 
-	sm.SetPinsMasked(0, pinMask)
-	sm.SetPindirsMasked(pinMask, pinMask)
+	sm.SetPinsMasked(0, pins.pinMask)
+	sm.SetPindirsMasked(pins.pinMask, pins.pinMask)
 	sm.Init(progOffset, scfg)
 	sm.SetEnabled(true)
 	return &Parallel{

--- a/rp2-pio/piolib/parallel_pins.go
+++ b/rp2-pio/piolib/parallel_pins.go
@@ -1,0 +1,23 @@
+//go:build rp2040 || rp2350
+
+package piolib
+
+import "machine"
+
+type parallelPins struct {
+	gpioBase uint32
+	clock    machine.Pin
+	dataBase machine.Pin
+	pinMask  uint32
+}
+
+// parallelPinMask returns the PIO pin mask for the clock pin and contiguous
+// data pins. The pin arguments must already be mapped into the PIO-relative
+// GPIOBASE window selected for the state machine.
+func parallelPinMask(clock, dataBase machine.Pin, busWidth uint8) uint32 {
+	mask := uint32(1) << uint(clock)
+	for pinoff := uint8(0); pinoff < busWidth; pinoff++ {
+		mask |= uint32(1) << uint(dataBase+machine.Pin(pinoff))
+	}
+	return mask
+}

--- a/rp2-pio/piolib/parallel_pins_rp2040.go
+++ b/rp2-pio/piolib/parallel_pins_rp2040.go
@@ -1,0 +1,31 @@
+//go:build rp2040
+
+package piolib
+
+import (
+	"errors"
+
+	pio "github.com/tinygo-org/pio/rp2-pio"
+)
+
+// parallelPinConfig validates RP2040 parallel bus pins and returns their
+// unchanged PIO-relative mapping. RP2040 PIO can only address GPIO0..31.
+func parallelPinConfig(cfg ParallelConfig) (parallelPins, error) {
+	if cfg.Clock >= 32 {
+		return parallelPins{}, errors.New("parallel pins exceed supported GPIO range")
+	}
+	if uint32(cfg.DataBase)+uint32(cfg.BusWidth) > 32 {
+		return parallelPins{}, errors.New("parallel pins exceed supported GPIO range")
+	}
+
+	return parallelPins{
+		clock:    cfg.Clock,
+		dataBase: cfg.DataBase,
+		pinMask:  parallelPinMask(cfg.Clock, cfg.DataBase, cfg.BusWidth),
+	}, nil
+}
+
+// setParallelGPIOBase is a no-op on RP2040, which does not support PIO
+// GPIOBASE remapping.
+func setParallelGPIOBase(_ *pio.PIO, _ uint32) {
+}

--- a/rp2-pio/piolib/parallel_pins_rp2350.go
+++ b/rp2-pio/piolib/parallel_pins_rp2350.go
@@ -1,0 +1,47 @@
+//go:build rp2350
+
+package piolib
+
+import (
+	"errors"
+
+	pio "github.com/tinygo-org/pio/rp2-pio"
+)
+
+// parallelPinConfig validates RP2350 parallel bus pins and maps physical GPIO
+// numbers into the PIO-relative GPIOBASE window needed to address them.
+func parallelPinConfig(cfg ParallelConfig) (parallelPins, error) {
+	clock := uint32(cfg.Clock)
+	dataBase := uint32(cfg.DataBase)
+	dataEnd := dataBase + uint32(cfg.BusWidth) - 1
+
+	if clock > 47 || dataEnd > 47 {
+		return parallelPins{}, errors.New("parallel pins exceed supported GPIO range")
+	}
+
+	if clock < 32 && dataEnd < 32 {
+		return parallelPins{
+			clock:    cfg.Clock,
+			dataBase: cfg.DataBase,
+			pinMask:  parallelPinMask(cfg.Clock, cfg.DataBase, cfg.BusWidth),
+		}, nil
+	}
+
+	if clock < 16 || dataBase < 16 {
+		return parallelPins{}, errors.New("parallel pins span incompatible GPIOBASE windows")
+	}
+
+	relativeClock := cfg.Clock - 16
+	relativeDataBase := cfg.DataBase - 16
+	return parallelPins{
+		gpioBase: 16,
+		clock:    relativeClock,
+		dataBase: relativeDataBase,
+		pinMask:  parallelPinMask(relativeClock, relativeDataBase, cfg.BusWidth),
+	}, nil
+}
+
+// setParallelGPIOBase applies the selected PIO GPIOBASE window on RP2350.
+func setParallelGPIOBase(pio *pio.PIO, base uint32) {
+	pio.SetGPIOBase(base)
+}


### PR DESCRIPTION
Fixes https://github.com/tinygo-org/pio/issues/56; unlocks Tufty2350 support

Map physical GPIO pins to the correct PIO-relative GPIOBASE window before claiming resources in NewParallel, so the parallel bus can drive data lines above GPIO31 on RP2350B (e.g. Pimoroni Tufty 2350 using pico-plus2: WR on GPIO30, DB0..DB7 on GPIO32..GPIO39).

RP2040 and low-GPIO RP2350 behavior is preserved unchanged (GPIOBASE 0). RP2350 layouts spanning incompatible GPIOBASE windows, or exceeding the supported GPIO range, are rejected. Physical machine pins are configured with their original numbers; PIO pin masks and state-machine OUT/SIDESET bases use the mapped relative numbers. Target-specific pin mapping lives in build-tagged
parallel_pins_rp2040.go and parallel_pins_rp2350.go so RP2040 does not reference the RP2350-only SetGPIOBase method.

Also validate BusWidth == 0 before evaluating BitsPerPull % BusWidth, so invalid zero-width input returns an error instead of panicking.