### PR TITLE
add new Base API based on @davecheney parallel changes

### DIFF
--- a/rp2-pio/pio.go
+++ b/rp2-pio/pio.go
@@ -431,3 +431,24 @@ type noCopy struct{}
 // Lock is a no-op used by -copylocks checker from `go vet`.
 func (*noCopy) Lock()   {}
 func (*noCopy) UnLock() {}
+
+// GPIOBase checks base of used pins. When using ranges of pins
+// you only need to pass in the "highest" pin of the range.
+// if OK is false then pin set is invalid: either
+// they do not share the same base or they are out of device pin range.
+// Base should be then set with [SetGPIOBase] and base value subtracted from pins.
+func GPIOBase(pins ...machine.Pin) (base uint32, ok bool) {
+	ok = true
+	expectLowbase := pins[0] < 32
+	for _, pin := range pins {
+		lowbase := pin < 32
+		if pin >= numPins || expectLowbase != lowbase {
+			ok = false // exceeded number of pins or mismatched base between pins.
+			break
+		}
+	}
+	if ok && !expectLowbase {
+		base = 16
+	}
+	return base, ok
+}

--- a/rp2-pio/pio_rp2040.go
+++ b/rp2-pio/pio_rp2040.go
@@ -11,6 +11,7 @@ import (
 const (
 	rp2350ExtraReg = 0
 	numPIO         = 2
+	numPins        = 32
 
 	// validINTEBits defines valid interrupt source bits for RP2040.
 	// RP2040 only supports 12 bits: FIFO status (bits 0-7) and IRQ flags 0-3 (bits 8-11).
@@ -49,6 +50,13 @@ func irqSet(num uint32, enabled bool) {
 		return
 	}
 	irqSetMask(1<<num, enabled)
+}
+
+// SetGPIOBase configures the GPIO base for the PIO block. On RP2040 can only receive 0.
+func (pio *PIO) SetGPIOBase(base uint32) {
+	if base != 0 {
+		panic("tried to set non-zero base on RP2040")
+	}
 }
 
 func irqSetMask(mask uint32, enabled bool) {

--- a/rp2-pio/pio_rp2350.go
+++ b/rp2-pio/pio_rp2350.go
@@ -12,7 +12,7 @@ const (
 	rp2350ExtraReg = 1
 	numPIO         = 3
 	_NUMIRQ        = 52
-
+	numPins        = 48
 	// validINTEBits defines valid interrupt source bits for RP2350.
 	// RP2350 supports all 16 bits: FIFO status (bits 0-7) and all IRQ flags 0-7 (bits 8-15).
 	validINTEBits IRQSource = 0xFFFF


### PR DESCRIPTION
@davecheney heya, saw one of your recent PRs and came up with this API for having a common way of base setting on RP2040/RP2350. I think it should reduce the code on one of your PRs significantly. Currently heading out so can't provide demo, in a bit I'll get back to this. Referring to https://github.com/tinygo-org/pio/pull/57